### PR TITLE
More SVLEN/END improvements

### DIFF
--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -474,7 +474,15 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
         if (info_end != this->position){
             cerr << "Warning: insertion END and POS do not agree (complex insertions not canonicalizeable) [canonicalize] " <<
             *this << endl << "END: " << info_end << "  " << "POS: " << this->position << endl;
-            return false;
+            
+            if (info_end == this->position + info_len) {
+                // We can probably guess what they meant here.
+                cerr << "Warning: VCF writer incorrecty produced END = POS + SVLEN for an insertion. Fixing END to POS." << endl;
+                info_end = this->position;
+                this->info["END"][0] = to_string(info_end);
+            } else {
+                return false;
+            }
         }
         
         if (info_len != info_span){
@@ -591,7 +599,15 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
         if (info_len != 0){
             cerr << "Warning: inversion SVLEN specifies nonzero length change (complex inversions not canonicalizeable) [canonicalize] " <<
             *this << endl << "SVLEN: " << info_len << endl;
-            return false;
+            
+            if (info_end == this->position + info_len) {
+                // We can probably guess what they meant here.
+                cerr << "Warning: VCF writer incorrecty produced END = POS + SVLEN for an inversion. Fixing SVLEN to 0." << endl;
+                info_len = 0;
+                this->info["SVLEN"][0] = to_string(info_len);
+            } else {
+                return false;
+            }
         }
     
         if (place_seq){

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -206,13 +206,28 @@ string Variant::getSVTYPE(int altpos) const{
 
 
 int Variant::getMaxReferencePos(){
+    if (this->canonical && this->info.find("END") != this->info.end()) {
+        // We are cannonicalized and must have a correct END
+        
+        int end = 0;
+        for (auto s : this->info.at("END")){
+            // Get the latest one defined.
+            end = max(abs(stoi(s)), end);
+        }
+        // Convert to 0-based.
+        return end - 1;
+        
+    }
+
     if (!this->isSymbolicSV()){
+        // We don't necessarily have an END, but we don't need one
         return this->zeroBasedPosition() + this->ref.length() - 1;
     }
-    else if (this->canonicalizable()){
+    
+    if (this->canonicalizable()){
+        // We aren't canonical, but we could be.
         if (this->info.find("END") != this->info.end()){
-            // An endpoint is defined
-            
+            // We have an END; blindly trust it
             int end = 0;
             for (auto s : this->info.at("END")){
                 // Get the latest one defined.
@@ -220,6 +235,7 @@ int Variant::getMaxReferencePos(){
             }
             // Convert to 0-based.
             return end - 1;
+            
         }
         else if (this->info.find("SVLEN") != this->info.end()){
             // There's no endpoint, but we know an SVLEN.
@@ -233,7 +249,7 @@ int Variant::getMaxReferencePos(){
                 }
                 deleted = max(-alt_len, deleted); 
             }
-           
+            
             // The anchoring base at POS gets added in (because it isn't
             // deleted) but then subtracted out (because we have to do that to
             // match non-SV deletions). For insertions, deleted is 0 and we
@@ -291,7 +307,7 @@ bool Variant::canonicalizable(){
     }
     else if (svtype == "DEL"){
         // Deletions need an SVLEN, SPAN, or END
-        return has_seq || has_span || has_end;
+        return has_len || has_span || has_end;
     }
     else if (svtype == "INV"){
         // Inversions need a SPAN or END
@@ -355,8 +371,16 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
         // Get the END from the reference sequence, which is ready.
         info_end = this->position + this->ref.length() - 1;
     }
+    else if ((svtype == "DEL" || svtype == "INV") && has_span) {
+        // For deletions and inversions, we can get the END from the SPAN
+        info_end = this->position + abs(stol(this->info.at("SPAN")[0]));
+    }
+    else if (svtype == "DEL" && has_len) {
+        // For deletions, we can get the END from the SVLEN
+        info_end = this->position + abs(stol(this->info.at("SVLEN")[0]));
+    }
     else if (svtype == "INS"){
-        // For insertions, END is just POS
+        // For insertions, END is just POS if not specified
         info_end = this->position;
     }
     else{
@@ -369,17 +393,24 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
     this->info["END"][0] = to_string(info_end);
     has_end = true;
     
-    // What is the variant length?
+    // What is the variant length change?
     // We store it as absolute value
     long info_len = 0;
     if (has_len){
         // Get the SVLEN from the tag
         info_len = abs(stol(this->info.at("SVLEN")[0]));
     }
-    else if (has_span){
+    else if ((svtype == "INS" || svtype == "DEL") && has_span){
         info_len = abs(stol(this->info.at("SPAN")[0]));
-    } else if (has_end && (svtype == "INV" || svtype == "DEL")) {
+    }
+    else if (svtype == "DEL"){
+        // We always have the end by now
+        // Deletion ends give you length change
         info_len = info_end - this->position;
+    } 
+    else if (svtype == "INV"){
+        // Inversions have 0 length change unless otherwise specified.
+        info_len = 0;
     }
     else{
         cerr << "Warning: could not set SVLEN info " << *this << endl;
@@ -397,16 +428,63 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
         this->info["SVLEN"].resize(1);
         this->info["SVLEN"][0] = to_string(info_len);
     }
+    // Now the length change is known
+    has_len = true;
     
-    
-    if (svtype == "INV" &&  (this->position + info_len != info_end)){
-        cerr << "Warning: inversion END and SVLEN do not agree [canonicalize] " << *this << endl <<
-        "END: " << info_end << "  " << "SVLEN: " << this->position + info_len << endl;
+    // We also compute a span
+    long info_span = 0;
+    if (has_span){
+        // Use the specified span
+        info_span = abs(stol(this->info.at("SVLEN")[0]));
+    }
+    else if (svtype == "INS" || svtype == "DEL"){
+        // has_len is always true here
+        // Insertions and deletions let us determine the span from the length change, unless they are complex.
+        info_span = info_len;
+    }
+    else if (svtype == "INV"){
+        // has_end is always true here
+        // Inversion span is start to end
+        info_span = info_end - this->position;
+    }
+    else{
+        cerr << "Warning: could not set SPAN info " << *this << endl;
         return false;
     }
-
+    
+    // Commit the SPAN back
+    this->info["SPAN"].resize(1);
+    this->info["SPAN"][0] = to_string(info_span);
+    // Now the span change is known
+    has_span = true;
+    
+    if (info_end < this->position) {
+        cerr << "Warning: SV END is before POS [canonicalize] " <<
+        *this << endl << "END: " << info_end << "  " << "POS: " << this->position << endl;
+        return false;
+    }
+     
     // Set the other necessary SV Tags (SVTYPE, SEQ (if insertion))
+    // Also check for agreement in the position tags
     if (svtype == "INS"){
+        if (info_end != this->position){
+            cerr << "Warning: insertion END and POS do not agree (complex insertions not canonicalizeable) [canonicalize] " <<
+            *this << endl << "END: " << info_end << "  " << "POS: " << this->position << endl;
+            return false;
+        }
+        
+        if (info_len != info_span){
+            cerr << "Warning: insertion SVLEN and SPAN do not agree (complex insertions not canonicalizeable) [canonicalize] " <<
+            *this << endl << "SVLEN: " << info_len << "  " << "SPAN: " << info_span << endl;
+            return false;
+        }
+       
+        if (has_seq && allATGCN(this->info.at("SEQ")[0]) && this->info.at("SEQ")[0].size() != info_len){
+            cerr << "Warning: insertion SVLEN and SEQ do not agree (complex insertions not canonicalizeable) [canonicalize] " <<
+            *this << endl << "SVLEN: " << info_len << "  " << "SEQ length: " << this->info.at("SEQ")[0].size() << endl;
+            return false;
+        }
+       
         // Set REF
         string ref_base = fasta_reference.getSubSequence(this->sequenceName, this->zeroBasedPosition(), 1);
         if (place_seq){
@@ -418,11 +496,11 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
                  allATGCN(this->info.at("SEQ")[0])){
             // Try to remove prepended ref sequence, assuming it's left-aligned
             string s = this->alt[0];
-            s.substr(this->ref.length());
+            s = s.substr(this->ref.length());
             if (s != this->info.at("SEQ")[0] && !place_seq){
                 cerr << "Warning: INS sequence in alt field does not match SEQ tag" << endl <<
                 this->alt[0] << " " << this->info.at("SEQ")[0] << endl;
-                //return false;
+                return false;
             }
             if (place_seq){
                 this->alt[0].assign( ref_base + this->info.at("SEQ")[0] );
@@ -431,9 +509,16 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
         }
         else if (alt_i_atgcn[0] && !has_seq){
             string s = this->alt[0];
-            s.substr(this->ref.length());
+            s = s.substr(this->ref.length());
             this->info["SEQ"].resize(1);
             this->info.at("SEQ")[0].assign(s);
+            
+            if (s.size() != info_len){
+                cerr << "Warning: insertion SVLEN and added bases do not agree (complex insertions not canonicalizeable) [canonicalize] " <<
+                *this << endl << "SVLEN: " << info_len << "  " << "added bases: " << s.size() << endl;
+                return false;
+            }
+            
         }
         else if (alt[0][0] == '<' && do_external_insertions){
 
@@ -449,6 +534,16 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
                         this->alt[0].assign(ref_base + ins_seq);
                     }
                 }
+                else {
+                    cerr << "Warning: Loaded invalid alt sequence for: " << *this << endl;
+                    return false;    
+                }
+                
+                if (ins_seq.size() != info_len){
+                    cerr << "Warning: insertion SVLEN and FASTA do not agree (complex insertions not canonicalizeable) [canonicalize] " <<
+                    *this << endl << "SVLEN: " << info_len << "  " << "FASTA bases: " << ins_seq.size() << endl;
+                    return false;
+                }
             } 
             else{
                 cerr << "Warning: Could not locate alt sequence for: " << *this << endl;
@@ -462,6 +557,18 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
         }
     }
     else if (svtype == "DEL"){
+        if (this->position + info_span != info_end){
+            cerr << "Warning: deletion END and SVLEN do not agree [canonicalize] " << *this << endl <<
+            "END: " << info_end << "  " << "SVLEN: " << -info_len << endl;
+            return false;
+        }
+    
+        if (this->position + info_span != info_end){
+            cerr << "Warning: deletion END and SPAN do not agree [canonicalize] " << *this << endl <<
+            "END: " << info_end << "  " << "SPAN: " << info_span << endl;
+            return false;
+        }
+    
         // Set REF
         if (place_seq){
             string del_seq = fasta_reference.getSubSequence(this->sequenceName, this->zeroBasedPosition(), info_len + 1);
@@ -469,9 +576,20 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
             this->ref.assign( del_seq );
             this->alt[0].assign( ref_base );
         }
-        this->info.at("SVLEN")[0].assign( to_string( -1 * info_len));
     }
     else if (svtype == "INV"){
+        if (this->position + info_span != info_end){
+            cerr << "Warning: inversion END and SPAN do not agree [canonicalize] " << *this << endl <<
+            "END: " << info_end << "  " << "SPAN: " << info_span << endl;
+            return false;
+        }
+        
+        if (info_len != 0){
+            cerr << "Warning: inversion SVLEN specifies nonzero length change (complex inversions not canonicalizeable) [canonicalize] " <<
+            *this << endl << "SVLEN: " << info_len << endl;
+            return false;
+        }
+    
         if (place_seq){
             string ref_seq = fasta_reference.getSubSequence(this->sequenceName, this->zeroBasedPosition(), info_len + 1);
             // Note that inversions still need an anchoring left base at POS

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -412,6 +412,10 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
         // Inversions have 0 length change unless otherwise specified.
         info_len = 0;
     }
+    else if (svtype == "INS" && has_seq) {
+        // Insertions can let us pick it up from the SEQ tag
+        info_len = this->info.at("SEQ").at(0).size();
+    }
     else{
         cerr << "Warning: could not set SVLEN info " << *this << endl;
         return false;
@@ -546,7 +550,7 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
                 }
             } 
             else{
-                cerr << "Warning: Could not locate alt sequence for: " << *this << endl;
+                cerr << "Warning: could not locate alt sequence for: " << *this << endl;
                 return false;
             }
             

--- a/src/Variant.h
+++ b/src/Variant.h
@@ -272,6 +272,7 @@ public:
     
     /**
      * Get the maximum zero-based position of the reference affected by this variant.
+     * Only works reliably for variants that are not SVs or for SVs that have been canonicalize()'d.
      */
     int getMaxReferencePos();
    


### PR DESCRIPTION
This PR adds some code to cross-check SVLEN, END, SEQ, and SPAN against each other. It also adds fixup capability to canonicalize() so it will tolerate variants written with POS + END = SVLEN and correct the fields to their spec-compliant values in that case.