### PR TITLE
Reset the canonical flag when a variant is parsed

### DIFF
--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -86,6 +86,7 @@ void Variant::parse(string& line, bool parseSamples) {
     format.clear();
     alt.clear();
     alleles.clear();
+    canonical = false;
 
     // #CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT [SAMPLE1 .. SAMPLEN]
     vector<string> fields = split(line, '\t');

--- a/src/Variant.h
+++ b/src/Variant.h
@@ -274,7 +274,7 @@ public:
     /**
      * This gets set to true after canonicalize() has been called on the variant, if it succeeded.
      */
-    bool canonical = false;
+    bool canonical;
     
     /**
      * Get the maximum zero-based position of the reference affected by this variant.


### PR DESCRIPTION
Having a default value in the class doesn't cut it and is misleading since single instances can overwrite themselves repeatedly.