### PR TITLE
dont assume lowercase means symbolic

### DIFF
--- a/src/Variant.h
+++ b/src/Variant.h
@@ -58,7 +58,7 @@ typedef vector<pair<int, string> > Cigar;
 std::string reverse_complement(const std::string& seq);
 /// Convert a sequence to upper-case
 std::string toUpper(const std::string& seq);
-bool allATGCN(const string& s, bool allowLowerCase = false);
+bool allATGCN(const string& s, bool allowLowerCase = true);
 
 class VariantCallFile {
 


### PR DESCRIPTION
Lowercase letters are used throughout `Variant::isSymbolicSV()`, `Variant::canonicalizable()` etc. to check if an allele is symbolic.  This leads, for example, to `isSymbolicSV()` returning true for this GIAB variant just because the ALT allele is `a` not `A`, which doesn't make much sense.
```
22	47607674	HG2_PB_assemblyticsPBcR_16410	ACCGTCCACACTAAATATGTGCGTGTCCACACT	a	20	lt50bp	BREAKSIMLENGTH=0;CGcalls=0;CGexactcalls=0;ClusterIDs=HG3_Ill_250bpfermikitraw_24753:
HG2_PB_assemblyticsPBcR_16410:HG2_PB_assemblyticsfalcon_16952;ClusterMaxEditDist=0.0588235;ClusterMa
xShiftDist=0.0588235;ClusterMaxSizeDiff=0.0588235;DistBack=-60;DistForward=-16;DistMin=-60;DistMinlt
1000=TRUE;DistPASSHG2gt49Minlt1000=.;DistPASSMinlt1000=.;END=47607706;ExactMatchIDs=HG2_PB_assemblyt
icsPBcR_16410:HG2_PB_assemblyticsfalcon_16952;HG003_GT=0/1;HG004_GT=./.;HG2count=2;HG3count=1;HG4cou
nt=0;Illcalls=1;Illexactcalls=0;MendelianError=.;MultiTech=TRUE;MultiTechExact=FALSE;NumClusterSVs=3
;NumExactMatchSVs=2;NumTechs=2;NumTechsExact=1;PBcalls=2;PBexactcalls=2;REFWIDENED=22:47607673-47607
707;REPTYPE=SIMPLEDEL;SVLEN=-32;SVTYPE=DEL;TRall=TRUE;TRgt100=TRUE;TRgt10k=FALSE;TenXcalls=0;TenXexa
ctcalls=0;segdup=FALSE;sizecat=20to49
```
This PR just switches `Variant::allATGCN()`, which is only used for symbolic determination in Variant.cpp, to allow lowercase by default. 
