### PR TITLE
Old interval tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ scriptToBin: $(BINS)
 
 GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always)
 
-CXXFLAGS = -O3 -D_FILE_OFFSET_BITS=64 -std=c++0x
+CXXFLAGS = -O3 -D_FILE_OFFSET_BITS=64 -std=c++11 -ggdb
 #CXXFLAGS = -O2
 #CXXFLAGS = -pedantic -Wall -Wshadow -Wpointer-arith -Wcast-qual
 

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -388,7 +388,7 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
     bool has_end = this->info.count("END") && !this->info.at("END").empty();
     
     // Where is the end, or where should it be?
-    uint64_t info_end = 0;
+    int64_t info_end = 0;
     if (has_end) {
         // Get the END from the tag
         info_end = stoull(this->info.at("END")[0]);
@@ -421,7 +421,7 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
     
     // What is the variant length change?
     // We store it as absolute value
-    uint64_t info_len = 0;
+    int64_t info_len = 0;
     if (has_len){
         // Get the SVLEN from the tag
         info_len = abs(stoll(this->info.at("SVLEN")[0]));
@@ -462,7 +462,7 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
     has_len = true;
     
     // We also compute a span
-    uint64_t info_span = 0;
+    int64_t info_span = 0;
     if (has_span){
         // Use the specified span
         info_span = abs(stol(this->info.at("SVLEN")[0]));

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -314,6 +314,7 @@ bool Variant::canonicalizable(){
     
     if (svtype.empty()){
         // We have no SV type, so we can't interpret things.
+        cerr << "No SV type information. Variant cannot be canonicalized: " << *this << endl;
         return false;
     }
     

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -388,10 +388,10 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
     bool has_end = this->info.count("END") && !this->info.at("END").empty();
     
     // Where is the end, or where should it be?
-    long info_end = 0;
+    uint64_t info_end = 0;
     if (has_end) {
         // Get the END from the tag
-        info_end = stol(this->info.at("END")[0]);
+        info_end = stoull(this->info.at("END")[0]);
     }
     else if(ref_valid && !place_seq) {
         // Get the END from the reference sequence, which is ready.
@@ -421,13 +421,13 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
     
     // What is the variant length change?
     // We store it as absolute value
-    long info_len = 0;
+    uint64_t info_len = 0;
     if (has_len){
         // Get the SVLEN from the tag
-        info_len = abs(stol(this->info.at("SVLEN")[0]));
+        info_len = abs(stoll(this->info.at("SVLEN")[0]));
     }
     else if ((svtype == "INS" || svtype == "DEL") && has_span){
-        info_len = abs(stol(this->info.at("SPAN")[0]));
+        info_len = abs(stoll(this->info.at("SPAN")[0]));
     }
     else if (svtype == "DEL"){
         // We always have the end by now
@@ -462,7 +462,7 @@ bool Variant::canonicalize(FastaReference& fasta_reference, vector<FastaReferenc
     has_len = true;
     
     // We also compute a span
-    long info_span = 0;
+    uint64_t info_span = 0;
     if (has_span){
         // Use the specified span
         info_span = abs(stol(this->info.at("SVLEN")[0]));

--- a/src/vcfnormalizesvs.cpp
+++ b/src/vcfnormalizesvs.cpp
@@ -92,7 +92,10 @@ int main(int argc, char** argv) {
 
     Variant var;
     while (variantFile.getNextVariant(var)) {
-        bool valid = var.canonicalize(ref, insertions, replace_sequences, min_size);
+        bool valid = false;
+        if (var.canonicalizable()){
+            valid = var.canonicalize(ref, insertions, replace_sequences, min_size);
+        }
         if (!valid){
             cerr << "Variant could not be normalized" << var << endl;
         }


### PR DESCRIPTION
This fixes an issue where vcflib won't build. Intervaltree was updated and the API changed significantly. Some of our executables (e.g. BedReader) were never updated to reflect this, so I've just bumped back to the "old" intervaltree to fix the build.

While I'm here, I'm hardening vcflib against some arithmetic errors because I keep hitting them mysteriously and I just really like predictably-sized numbers.